### PR TITLE
Opt-out PRs that have the `backport/manual` label

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -13,7 +13,7 @@ export const fetchCandidates = async (giteaMajorMinorVersion: string) => {
   const response = await fetch(
     `${GITHUB_API}/search/issues?q=` +
       encodeURIComponent(
-        `is:pr is:merged label:backport/v${giteaMajorMinorVersion} -label:backport/done repo:go-gitea/gitea`,
+        `is:pr is:merged label:backport/v${giteaMajorMinorVersion} -label:backport/done -label:backport/manual repo:go-gitea/gitea`,
       ),
     { headers: HEADERS },
   );


### PR DESCRIPTION
Some people do not want to have their PRs backported automatically, this adds an "opt-out" mechanism.

See the following quote:

              I think I would like to create my own backports instead of approving a backport another user created for me.

_Originally posted by @KN4CK3R in https://github.com/go-gitea/gitea/issues/22965#issuecomment-1448134423_
            