### PR TITLE
Add PR comment when backport fails

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -128,17 +128,17 @@ export const createBackportPr = async (
   const backportLabels = originalPr.labels
     .filter((label) => label.name.startsWith("backport/"));
   if (backportLabels.length === 1) {
-    await addBackportDoneLabel(originalPr.number);
+    await addLabels(originalPr.number, ["backport/done"]);
   }
 };
 
-export const addBackportDoneLabel = async (prNumber: number) => {
+export const addLabels = async (prNumber: number, labels: string[]) => {
   const response = await fetch(
     `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/labels`,
     {
       method: "POST",
       headers: HEADERS,
-      body: JSON.stringify({ labels: ["backport/done"] }),
+      body: JSON.stringify({ labels: labels }),
     },
   );
   const json = await response.json();

--- a/src/github.ts
+++ b/src/github.ts
@@ -155,7 +155,7 @@ export const addPRComment = async (prNumber: number, comment: string) => {
     {
       method: "POST",
       headers: HEADERS,
-      body: JSON.stringify({body: comment}),
+      body: JSON.stringify({ body: comment }),
     },
   );
   const json = await response.json();

--- a/src/github.ts
+++ b/src/github.ts
@@ -148,3 +148,20 @@ export const addBackportDoneLabel = async (prNumber: number) => {
     }`,
   );
 };
+
+export const addPRComment = async (prNumber: number, comment: string) => {
+    const response = await fetch(
+        `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/comments`,
+        {
+            method: "POST",
+            headers: HEADERS,
+            body: JSON.stringify({ body: comment }),
+        },
+    );
+    const json = await response.json();
+    console.log(
+        `Added backport comment to PR #${prNumber}: ${
+            json.map((c: { body: string }) => c.body)
+        }`,
+    );
+};

--- a/src/github.ts
+++ b/src/github.ts
@@ -150,18 +150,18 @@ export const addBackportDoneLabel = async (prNumber: number) => {
 };
 
 export const addPRComment = async (prNumber: number, comment: string) => {
-    const response = await fetch(
-        `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/comments`,
-        {
-            method: "POST",
-            headers: HEADERS,
-            body: JSON.stringify({ body: comment }),
-        },
-    );
-    const json = await response.json();
-    console.log(
-        `Added backport comment to PR #${prNumber}: ${
-            json.map((c: { body: string }) => c.body)
-        }`,
-    );
+  const response = await fetch(
+    `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/comments`,
+    {
+      method: "POST",
+      headers: HEADERS,
+      body: JSON.stringify({body: comment}),
+    },
+  );
+  const json = await response.json();
+  console.log(
+    `Added backport comment to PR #${prNumber}: ${
+      json.map((c: { body: string }) => c.body)
+    }`,
+  );
 };

--- a/src/github.ts
+++ b/src/github.ts
@@ -149,7 +149,7 @@ export const addLabels = async (prNumber: number, labels: string[]) => {
   );
 };
 
-export const addPRComment = async (prNumber: number, comment: string) => {
+export const addPrComment = async (prNumber: number, comment: string) => {
   const response = await fetch(
     `${GITHUB_API}/repos/go-gitea/gitea/issues/${prNumber}/comments`,
     {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -47,7 +47,7 @@ const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
   );
 
   if (!success) {
-    await addPRComment(
+    await addPrComment(
       originalPr.number,
       "I was unable to automate a backport, please send one manually. :tea:"
     );

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,9 +1,9 @@
 import { cherryPickPr, initializeGitRepo } from "./git.ts";
 import { GiteaVersion } from "./giteaVersion.ts";
 import {
+  addPRComment,
   backportPrExists,
   createBackportPr,
-  addPRComment,
   fetchCandidates,
   fetchPr,
   getMilestones,
@@ -46,7 +46,10 @@ const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
   );
 
   if (!success) {
-    await addPRComment(originalPr.number, "I was unable to automate a backport, please send one manually. :tea:")
+    await addPRComment(
+      originalPr.number,
+      "I was unable to automate a backport, please send one manually. :tea:"
+    );
     return;
   }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,7 +2,7 @@ import { cherryPickPr, initializeGitRepo } from "./git.ts";
 import { GiteaVersion } from "./giteaVersion.ts";
 import {
   addLabels,
-  addPRComment,
+  addPrComment,
   backportPrExists,
   createBackportPr,
   fetchCandidates,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -3,6 +3,7 @@ import { GiteaVersion } from "./giteaVersion.ts";
 import {
   backportPrExists,
   createBackportPr,
+  addPRComment,
   fetchCandidates,
   fetchPr,
   getMilestones,
@@ -44,7 +45,10 @@ const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
     giteaVersion.majorMinorVersion,
   );
 
-  if (!success) return;
+  if (!success) {
+    await addPRComment(originalPr.number, "I was unable to automate a backport, please send one manually. :tea:")
+    return;
+  }
 
   console.log(`Creating backport PR for #${originalPr.number}`);
   await createBackportPr(originalPr, giteaVersion);

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,7 @@
 import { cherryPickPr, initializeGitRepo } from "./git.ts";
 import { GiteaVersion } from "./giteaVersion.ts";
 import {
+  addLabels,
   addPRComment,
   backportPrExists,
   createBackportPr,
@@ -49,6 +50,10 @@ const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
     await addPRComment(
       originalPr.number,
       "I was unable to automate a backport, please send one manually. :tea:"
+    );
+    await addLabels(
+      originalPr.number,
+      ["backport/manual"]
     );
     return;
   }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -49,11 +49,11 @@ const parseCandidate = async (candidate, giteaVersion: GiteaVersion) => {
   if (!success) {
     await addPRComment(
       originalPr.number,
-      "I was unable to automate a backport, please send one manually. :tea:"
+      "I was unable to automate a backport, please send one manually. :tea:",
     );
     await addLabels(
       originalPr.number,
-      ["backport/manual"]
+      ["backport/manual"],
     );
     return;
   }


### PR DESCRIPTION
When a backport fails, it would be nice (imo) to comment on the original PR to signal that the backport may require manual intervention.